### PR TITLE
Updates for git-credential-manager

### DIFF
--- a/jetbrains/intellij-IDEA/complete/.devcontainer.postCreate.sh
+++ b/jetbrains/intellij-IDEA/complete/.devcontainer.postCreate.sh
@@ -64,17 +64,19 @@ python -m pip install launch-cli
 # cd ${work_dir}
 
 # Set up netrc
-echo "Setting /home/${container_user}/.netrc variables"
-echo "machine github.com
-login ${github_public_user}
-password ${git_token}" >> /home/${container_user}/.netrc
-chmod 600 /home/${container_user}/.netrc
+# echo "Setting /home/${container_user}/.netrc variables"
+# echo "machine github.com
+# login ${github_public_user}
+# password ${git_token}" >> /home/${container_user}/.netrc
+# chmod 600 /home/${container_user}/.netrc
 
 # Configure git
 echo "
 [user]
         name = ${github_public_user}
         email = ${github_public_email}
+[credential]
+        usehttppath = true
 [push]
         autoSetupRemote = true
 [safe]

--- a/vscode/complete/.devcontainer.postCreate.sh
+++ b/vscode/complete/.devcontainer.postCreate.sh
@@ -151,11 +151,11 @@ $current_python -m pip install ruamel_yaml
 #################
 
 # Set up netrc
-echo -e "\nSetting /home/${container_user}/.netrc variables..."
-echo machine github.com >> /home/${container_user}/.netrc
-echo login ${github_public_user} >> /home/${container_user}/.netrc
-echo password ${git_token} >> /home/${container_user}/.netrc
-chmod 600 /home/${container_user}/.netrc
+# echo -e "\nSetting /home/${container_user}/.netrc variables..."
+# echo machine github.com >> /home/${container_user}/.netrc
+# echo login ${github_public_user} >> /home/${container_user}/.netrc
+# echo password ${git_token} >> /home/${container_user}/.netrc
+# chmod 600 /home/${container_user}/.netrc
 
 # Configure git
 echo "Configuring git..."
@@ -163,7 +163,7 @@ echo "[user]
         name = ${github_public_user}
         email = ${github_public_email}
 [credential]
-        credentialStore = cache
+        usehttppath = true
 [push]
         autoSetupRemote = true
 [safe]

--- a/vscode/experimental/devcontainer.postCreate.sh
+++ b/vscode/experimental/devcontainer.postCreate.sh
@@ -148,11 +148,11 @@ python -m pip install ruamel_yaml
 #################
 
 # Set up netrc
-echo "Setting ~/.netrc variables..."
-echo machine github.com >> ~/.netrc
-echo login ${github_public_user} >> ~/.netrc
-echo password ${git_token} >> ~/.netrc
-chmod 600 /home/${container_user}/.netrc
+# echo "Setting ~/.netrc variables..."
+# echo machine github.com >> ~/.netrc
+# echo login ${github_public_user} >> ~/.netrc
+# echo password ${git_token} >> ~/.netrc
+# chmod 600 /home/${container_user}/.netrc
 
 # Configure git
 echo "Configuring git..."
@@ -160,7 +160,7 @@ echo "[user]
         name = ${github_public_user}
         email = ${github_public_email}
 [credential]
-        credentialStore = cache
+        usehttppath = true
 [push]
         autoSetupRemote = true
 [safe]


### PR DESCRIPTION
Having the .netrc set with a PAT preempts the containerized git process calling git-credential-manager on the host, which means that dev containers can only ever work with one set of credentials at a time.

This change to the container's postinstallation scripts will skip writing .netrc and will set `usehttppath = true` which is required to have Git distinguish between URL paths rather than just hostnames.